### PR TITLE
Added max-sockets CLI argument

### DIFF
--- a/bin/lambda-shearer.js
+++ b/bin/lambda-shearer.js
@@ -14,6 +14,7 @@ const argv = yargs
   .describe('lambda', 'lambda function name or ARN')
   .describe('payload', 'path to a file that contains JSON payload or function that produces one (is invoked with one argument: index)')
   .describe('region', 'AWS region')
+  .describe('max-sockets', 'number of sockets to use in HTTPS connection pool')
   .describe('repeats', 'number of lambda function invocations for each memory setting')
   .describe('concurrency', 'number of concurrent invocations to use')
   .describe('delay', 'delay before each invoke')
@@ -24,12 +25,14 @@ const argv = yargs
   .alias('lambda', 'l')
   .alias('payload', 'p')
   .alias('region', 'r')
+  .alias('max-sockets', 'm')
   .alias('concurrency', 'c')
   .alias('delay', 'd')
   .alias('repeats', 'n')
   .alias('steps', 's')
   .alias('verbose', 'v')
   .alias('warmup', 'w')
+  .default('max-sockets', Runner.MAX_SOCKETS)
   .default('repeats', 10)
   .default('verbose', false)
   .default('warmup', true)
@@ -46,7 +49,8 @@ const runnerOptions = {
   concurrency: Number(argv.concurrency),
   delay: Number(argv.delay),
   verbose: Boolean(argv.verbose),
-  warmup: Boolean(argv.warmup)
+  warmup: Boolean(argv.warmup),
+  maxSockets: Number(argv.maxSockets)
 };
 
 const runner = new Runner(runnerOptions);

--- a/lib/Runner.js
+++ b/lib/Runner.js
@@ -4,7 +4,9 @@ const AWS = require('aws-sdk');
 const EventEmitter = require('events');
 const BPromise = require('bluebird');
 const percentile = require('percentile');
+const https = require('https');
 
+const MAX_SOCKETS = 512;
 const REPORT_REGEX = /REPORT RequestId: ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\s+Duration: ([0-9.]+) ms\s+Billed Duration: ([0-9]+) ms\s+Memory Size: (\d+) MB\s+Max Memory Used: (\d+) MB\s+$/; // eslint-disable-line max-len
 const PERCENTILES = [50, 66, 75, 80, 90, 95, 98, 99];
 
@@ -14,7 +16,13 @@ class Runner extends EventEmitter {
 
     Object.assign(this, options);
 
+    this._setMaxSockets(this.maxSockets || MAX_SOCKETS);
     this.lambdaClient = new AWS.Lambda({ region: options.region });
+  }
+
+  _setMaxSockets(maxSockets) {
+    const agent = new https.Agent({ keepAlive: true, maxSockets });
+    AWS.config.update({ httpOptions: { agent } });
   }
 
   _getAllocatedMemory() {
@@ -134,4 +142,5 @@ class Runner extends EventEmitter {
   }
 }
 
+Runner.MAX_SOCKETS = MAX_SOCKETS;
 module.exports = Runner;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-shearer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Node CLI tool that helps to configure AWS Lambda function resources properly",
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
Allow the user to configure the maxSockets options in the AWS SDK.
These are the sockets that are reused for the HTTP connection pool
when producing Lambda invocations.

Keepalive is now enabled by default.

http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-configuring-maxsockets.html
https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_new_agent_options